### PR TITLE
feat: add YamlScalar.plain to distinguish plain and quoted scalars

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
@@ -44,6 +44,7 @@ public sealed class YamlNode(
 public data class YamlScalar(
     val content: String,
     override val path: YamlPath,
+    val plain: Boolean = true,
 ) : YamlNode(path) {
     override fun equivalentContentTo(other: YamlNode): Boolean = other is YamlScalar && this.content == other.content
 
@@ -157,6 +158,11 @@ public data class YamlScalar(
     internal fun toCharOrNull(): Char? = content.singleOrNull()
 
     override fun withPath(newPath: YamlPath): YamlScalar = this.copy(path = newPath)
+
+    // equals/hashCode intentionally exclude plain: the scalar style is a presentation detail and must not affect content equality.
+    override fun equals(other: Any?): Boolean = other is YamlScalar && content == other.content && path == other.path
+
+    override fun hashCode(): Int = 31 * content.hashCode() + path.hashCode()
 
     override fun toString(): String = "scalar @ $path : $content"
 }

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeReader.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeReader.kt
@@ -80,7 +80,7 @@ internal class YamlNodeReader(
         if ((event.value == "null" || event.value == "" || event.value == "~") && event.plain) {
             return YamlNull(path)
         } else {
-            return YamlScalar(event.value, path)
+            return YamlScalar(event.value, path, plain = event.plain)
         }
     }
 
@@ -121,8 +121,9 @@ internal class YamlNodeReader(
 
                 else -> {
                     val keyLocation = parser.peekEvent(path).location
-                    val key = readMapKey(path)
-                    val keyNode = YamlScalar(key, path.withMapElementKey(key, keyLocation))
+                    val keyEvent = readMapKey(path)
+                    val key = keyEvent.value
+                    val keyNode = YamlScalar(key, path.withMapElementKey(key, keyLocation), plain = keyEvent.plain)
 
                     val valueLocation = parser.peekEvent(keyNode.path).location
                     val valuePath = if (isMerge(keyNode)) path.withMerge(valueLocation) else keyNode.path.withMapElementValue(valueLocation)
@@ -141,7 +142,7 @@ internal class YamlNodeReader(
         }
     }
 
-    private fun readMapKey(path: YamlPath): String {
+    private fun readMapKey(path: YamlPath): ScalarEvent {
         val event = parser.peekEvent(path)
 
         when (event.eventId) {
@@ -154,7 +155,7 @@ internal class YamlNodeReader(
                     throw nonScalarMapKeyException(path, event)
                 }
 
-                return scalarEvent.value
+                return scalarEvent
             }
 
             else -> {

--- a/src/jvmTest/kotlin/com/charleskorn/kaml/YamlNodeReaderTest.kt
+++ b/src/jvmTest/kotlin/com/charleskorn/kaml/YamlNodeReaderTest.kt
@@ -62,6 +62,40 @@ class YamlNodeReaderTest :
                 }
             }
 
+            mapOf(
+                "0.10" to true,
+                "hello" to true,
+                "'0.10'" to false,
+                """"0.10"""" to false,
+                "'hello'" to false,
+                """"hello"""" to false,
+            ).forEach { (input, expectedPlain) ->
+                context("given the scalar '$input'") {
+                    describe("parsing that input") {
+                        val parser = YamlParser(input)
+                        val result = YamlNodeReader(parser).read()
+
+                        it("exposes whether the scalar was written in plain style") {
+                            (result as YamlScalar).plain shouldBe expectedPlain
+                        }
+                    }
+                }
+            }
+
+            describe("plain and quoted scalars with the same content") {
+                val plainScalar = YamlNodeReader(YamlParser("0.10")).read() as YamlScalar
+                val quotedScalar = YamlNodeReader(YamlParser("'0.10'")).read() as YamlScalar
+
+                it("preserve the same content") {
+                    plainScalar.content shouldBe quotedScalar.content
+                }
+
+                it("can be told apart via plain") {
+                    plainScalar.plain shouldBe true
+                    quotedScalar.plain shouldBe false
+                }
+            }
+
             // https://yaml.org/spec/1.2/spec.html#id2793979 is useful reference here, as is
             // https://yaml-multiline.info/
             mapOf(


### PR DESCRIPTION
## Problem

`YamlScalar` drops the scalar's style, so a plain and a quoted scalar with the same text are indistinguishable — breaking YAML tag resolution (plain `0.10` → float, `'0.10'` → string):

```kotlin
val plain  = Yaml.default.parseToYamlNode("0.10")   as YamlScalar
val quoted = Yaml.default.parseToYamlNode("'0.10'") as YamlScalar
plain.content == quoted.content // true — no way to tell the number from the string
```

## Spec

[YAML 1.2, Flow Scalar Styles](https://github.com/yaml/yaml-spec/blob/main/spec/1.2/markdown/spec.md#-flow-scalar-styles): the scalar style "must not be used to convey content information, with the exception that plain scalars are distinguished for the purpose of tag resolution". So `content` must stay style-independent, but the plain vs non-plain bit must be exposed.

## Change

- Add `YamlScalar.plain` (default `true`), populated from `ScalarEvent.plain` for both scalar values and map keys.
- Excluded from `equals`/`hashCode`: style is a presentation detail and must not affect content equality — same `content` and `path` stay equal regardless of quoting.
- Only exposes plain vs non-plain (enough for tag resolution), not the full style.

## Result

A consumer can now implement tag resolution and tell a number from a string:

```kotlin
fun resolve(s: YamlScalar): Any =
    if (s.plain) s.content.toDoubleOrNull() ?: s.content // "?" -> schema-typed
    else s.content                                       // "!" -> always string

resolve(plain)  // 0.1    (Double)
resolve(quoted) // "0.10" (String)
```