### PR TITLE
feat(common): implement collection interfaces for YamlList and YamlMap

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlInput.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlInput.kt
@@ -247,7 +247,7 @@ public sealed class YamlInput(
 
         private fun YamlMap.getValue(desiredKey: String): YamlNode = this.get(desiredKey) ?: throw MissingRequiredPropertyException(desiredKey, this.path)
 
-        private fun YamlMap.withoutKey(key: String): YamlMap = this.copy(entries = entries.filterKeys { it.content != key })
+        private fun YamlMap.withoutKey(key: String): YamlMap = this.copy(pairs = this.filterKeys { it.content != key })
 
         private val SerialDescriptor.isContentBasedPolymorphic get() = annotations.any { it is YamlContentPolymorphicSerializer.Marker }
     }

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlListInput.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlListInput.kt
@@ -35,16 +35,16 @@ internal class YamlListInput(
     private var nextElementIndex = 0
     private lateinit var currentElementDecoder: YamlInput
 
-    override fun decodeCollectionSize(descriptor: SerialDescriptor): Int = list.items.size
+    override fun decodeCollectionSize(descriptor: SerialDescriptor): Int = list.size
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
-        if (nextElementIndex == list.items.size) {
+        if (nextElementIndex == list.size) {
             return CompositeDecoder.DECODE_DONE
         }
 
         currentElementDecoder =
             createFor(
-                list.items[nextElementIndex],
+                list[nextElementIndex],
                 yaml,
                 serializersModule,
                 configuration,

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlMapInput.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlMapInput.kt
@@ -31,7 +31,7 @@ internal class YamlMapInput(
     context: SerializersModule,
     configuration: YamlConfiguration,
 ) : YamlMapLikeInputBase(map, yaml, context, configuration) {
-    private val entriesList = map.entries.entries.toList()
+    private val entriesList = map.entries.toList()
     private var nextIndex = 0
     private lateinit var currentEntry: Map.Entry<YamlScalar, YamlNode>
 

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
@@ -182,9 +182,10 @@ public data class YamlNull(
 
 @Serializable(with = YamlListSerializer::class)
 public data class YamlList(
-    val items: List<YamlNode>,
+    private val items: List<YamlNode>,
     override val path: YamlPath,
-) : YamlNode(path) {
+) : YamlNode(path),
+    List<YamlNode> by items {
     override fun equivalentContentTo(other: YamlNode): Boolean {
         if (other !is YamlList) {
             return false
@@ -196,8 +197,6 @@ public data class YamlList(
 
         return this.items.zip(other.items).all { (mine, theirs) -> mine.equivalentContentTo(theirs) }
     }
-
-    public operator fun get(index: Int): YamlNode = items[index]
 
     override fun contentToString(): String = "[" + items.joinToString(", ") { it.contentToString() } + "]"
 
@@ -227,12 +226,13 @@ public data class YamlList(
 
 @Serializable(with = YamlMapSerializer::class)
 public data class YamlMap(
-    val entries: Map<YamlScalar, YamlNode>,
+    private val pairs: Map<YamlScalar, YamlNode>,
     override val path: YamlPath,
-) : YamlNode(path) {
+) : YamlNode(path),
+    Map<YamlScalar, YamlNode> by pairs {
     init {
         val keys =
-            entries.keys.sortedWith { a, b ->
+            pairs.keys.sortedWith { a, b ->
                 val lineComparison = a.location.line.compareTo(b.location.line)
 
                 if (lineComparison != 0) {
@@ -259,16 +259,16 @@ public data class YamlMap(
             return false
         }
 
-        if (this.entries.size != other.entries.size) {
+        if (this.pairs.size != other.pairs.size) {
             return false
         }
 
-        return this.entries.all { (thisKey, thisValue) ->
-            other.entries.any { it.key.equivalentContentTo(thisKey) && it.value.equivalentContentTo(thisValue) }
+        return this.pairs.all { (thisKey, thisValue) ->
+            other.pairs.any { it.key.equivalentContentTo(thisKey) && it.value.equivalentContentTo(thisValue) }
         }
     }
 
-    override fun contentToString(): String = "{" + entries.map { (key, value) -> "${key.contentToString()}: ${value.contentToString()}" }.joinToString(", ") + "}"
+    override fun contentToString(): String = "{" + pairs.map { (key, value) -> "${key.contentToString()}: ${value.contentToString()}" }.joinToString(", ") + "}"
 
     /**
      * Returns the value corresponding to the given key and the given type,
@@ -277,7 +277,7 @@ public data class YamlMap(
      */
     public inline operator fun <reified T : YamlNode> get(key: String): T? {
         val node =
-            entries.entries
+            entries
                 .firstOrNull { it.key.content == key }
                 ?.value ?: return null // no such key in the map
         // if the value is not the given type,
@@ -295,11 +295,11 @@ public data class YamlMap(
             else -> throw IncorrectTypeException("Value for '$key' is not a scalar.", node.path)
         }
 
-    public fun getKey(key: String): YamlScalar? = entries.keys.singleOrNull { it.content == key }
+    public fun getKey(key: String): YamlScalar? = pairs.keys.singleOrNull { it.content == key }
 
     override fun withPath(newPath: YamlPath): YamlMap {
         val updatedEntries =
-            entries
+            pairs
                 .mapKeys { (k, _) -> k.withPath(replacePathOnChild(k, newPath)) }
                 .mapValues { (_, v) -> v.withPath(replacePathOnChild(v, newPath)) }
 
@@ -309,9 +309,9 @@ public data class YamlMap(
     override fun toString(): String {
         val builder = StringBuilder()
 
-        builder.appendLine("map @ $path (size: ${entries.size})")
+        builder.appendLine("map @ $path (size: ${pairs.size})")
 
-        entries.forEach { (key, value) ->
+        pairs.forEach { (key, value) ->
             builder.appendLine("- key:")
 
             key.toString().lines().forEach { line ->

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeReader.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeReader.kt
@@ -184,7 +184,7 @@ internal class YamlNodeReader(
 
             1 -> {
                 when (val mappingsToMerge = mergeEntries.single().value) {
-                    is YamlList -> return doMerges(items, mappingsToMerge.items)
+                    is YamlList -> return doMerges(items, mappingsToMerge)
                     else -> return doMerges(items, listOf(mappingsToMerge))
                 }
             }
@@ -230,7 +230,7 @@ internal class YamlNodeReader(
                     }
 
                     is YamlMap -> {
-                        other.entries.forEach { (key, value) ->
+                        other.forEach { (key, value) ->
                             val existingEntry = merged.entries.singleOrNull { it.key.equivalentContentTo(key) }
 
                             if (existingEntry == null) {

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeSerializer.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeSerializer.kt
@@ -134,7 +134,7 @@ internal object YamlMapSerializer : KSerializer<YamlMap> {
         value: YamlMap,
     ) {
         encoder.asYamlOutput()
-        MapSerializer(YamlScalarSerializer, YamlNodeSerializer).serialize(encoder, value.entries)
+        MapSerializer(YamlScalarSerializer, YamlNodeSerializer).serialize(encoder, value)
     }
 
     override fun deserialize(decoder: Decoder): YamlMap {
@@ -151,7 +151,7 @@ internal object YamlListSerializer : KSerializer<YamlList> {
         value: YamlList,
     ) {
         encoder.asYamlOutput()
-        ListSerializer(YamlNodeSerializer).serialize(encoder, value.items)
+        ListSerializer(YamlNodeSerializer).serialize(encoder, value)
     }
 
     override fun deserialize(decoder: Decoder): YamlList {

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlObjectInput.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlObjectInput.kt
@@ -31,7 +31,7 @@ internal class YamlObjectInput(
     context: SerializersModule,
     configuration: YamlConfiguration,
 ) : YamlMapLikeInputBase(map, yaml, context, configuration) {
-    private val entriesList = map.entries.entries.toList()
+    private val entriesList = map.entries.toList()
     private var nextIndex = 0
     private lateinit var pairedPropertyNames: Map<String, Int>
 

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlListTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlListTest.kt
@@ -40,11 +40,11 @@ class YamlListTest :
         }
 
         test("list equivalence with same items but different path") {
-            list.equivalentContentTo(YamlList(list.items, YamlPath.root.withMapElementValue(Location(5, 6)))) shouldBe true
+            list.equivalentContentTo(YamlList(list, YamlPath.root.withMapElementValue(Location(5, 6)))) shouldBe true
         }
 
         test("list equivalence with same items in different order") {
-            list.equivalentContentTo(YamlList(list.items.reversed(), list.path)) shouldBe false
+            list.equivalentContentTo(YamlList(list.reversed(), list.path)) shouldBe false
         }
 
         test("list equivalence with different items") {

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlMapTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlMapTest.kt
@@ -117,7 +117,7 @@ class YamlMapTest :
 
                 context("comparing it to another map with the same items in the same order with a different path") {
                     test("indicates that they are equivalent") {
-                        map.equivalentContentTo(YamlMap(map.entries, YamlPath.root.withListEntry(0, Location(3, 4)))) shouldBe true
+                        map.equivalentContentTo(YamlMap(map, YamlPath.root.withListEntry(0, Location(3, 4)))) shouldBe true
                     }
                 }
 

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
@@ -320,7 +320,7 @@ class YamlReadingTest :
 
                 context("parsing that input as a list node") {
                     val result = Yaml.default.decodeFromString(TestClassWithNestedList.serializer(), input)
-                    val resultList = result.node.items.map { if (it is YamlNull) null else it.yamlScalar.toDouble() }
+                    val resultList = result.node.map { if (it is YamlNull) null else it.yamlScalar.toDouble() }
 
                     test("deserializes list") {
                         resultList shouldBe listOf(1.2, 3.0, Double.POSITIVE_INFINITY, null)
@@ -336,7 +336,7 @@ class YamlReadingTest :
 
                     test("deserializes node to double list") {
                         val resultList =
-                            result.node.yamlList.items
+                            result.node.yamlList
                                 .map { if (it is YamlNull) null else it.yamlScalar.toDouble() }
                         resultList shouldBe listOf(1.2, 3.0, Double.POSITIVE_INFINITY, null)
                     }
@@ -1046,13 +1046,12 @@ class YamlReadingTest :
                     val result = Yaml.default.decodeFromString(TestClassWithNestedMap.serializer(), input)
 
                     test("deserializes map") {
-                        result.node.entries shouldHaveSize 5
+                        result.node shouldHaveSize 5
                         result.node.get<YamlScalar>("foo1")!!.content shouldBe "bar"
                         result.node.get<YamlNull>("foo2").shouldBeInstanceOf<YamlNull>()
                         result.node.get<YamlScalar>("foo3")!!.toDouble() shouldBe 3.14
                         result.node
                             .get<YamlList>("foo4")!!
-                            .items
                             .map { it.yamlScalar.toInt() } shouldBe listOf(1, 2, 3)
                         result.node
                             .get<YamlMap>("foo5")!!
@@ -1074,11 +1073,11 @@ class YamlReadingTest :
 
                     test("deserializes node to double list") {
                         val node = result.node.yamlMap
-                        node.entries shouldHaveSize 5
+                        node shouldHaveSize 5
                         node.get<YamlScalar>("foo1")!!.content shouldBe "bar"
                         node.get<YamlNull>("foo2").shouldBeInstanceOf<YamlNull>()
                         node.get<YamlScalar>("foo3")!!.toDouble() shouldBe 3.14
-                        node.get<YamlList>("foo4")!!.items.map { it.yamlScalar.toInt() } shouldBe listOf(1, 2, 3)
+                        node.get<YamlList>("foo4")!!.map { it.yamlScalar.toInt() } shouldBe listOf(1, 2, 3)
                         node.get<YamlMap>("foo5")!!.get<YamlScalar>("element1")!!.toInt() shouldBe 1
                         node.get<YamlMap>("foo5")!!.get<YamlScalar>("element2")!!.toInt() shouldBe 2
                     }
@@ -2422,7 +2421,7 @@ class YamlReadingTest :
 
                             override fun deserialize(decoder: Decoder): List<Database> {
                                 check(decoder is YamlInput)
-                                return decoder.node.yamlMap.entries.map { (_, value) ->
+                                return decoder.node.yamlMap.map { (_, value) ->
                                     decoder.yaml.decodeFromYamlNode(Database.serializer(), value)
                                 }
                             }
@@ -2631,7 +2630,7 @@ private object DecodingFromYamlNodeSerializer : KSerializer<DatabaseListing> {
         check(decoder is YamlInput)
 
         val list =
-            decoder.node.yamlMap.entries.map { (_, value) ->
+            decoder.node.yamlMap.map { (_, value) ->
                 decoder.yaml.decodeFromYamlNode(Database.serializer(), value)
             }
 
@@ -2672,7 +2671,7 @@ private object SerializerForObjectWithCustomSerializer : KSerializer<ObjectWithC
 
         // Intentionally parse the values from the current yaml node
         val values =
-            decoder.node.yamlList.items
+            decoder.node.yamlList
                 .map { it.yamlScalar.content }
 
         return ObjectWithCustomSerializer(values.joinToString(VALUES_SEPARATOR))


### PR DESCRIPTION
Make YamlList and YamlMap can perform like JsonArray and JsonObject in official JSON format support in kotlinx.serialization.

All tests pass on local, spotless rules applied.