### PR TITLE
chore: remove KT-69327 workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Add the following to your Gradle build script:
 
 ```kotlin
 plugins {
-    kotlin("jvm").version("2.4.0")
-    kotlin("plugin.serialization").version("2.4.0")
+    kotlin("jvm").version("2.4.10")
+    kotlin("plugin.serialization").version("2.4.10")
 }
 
 dependencies {

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
@@ -76,7 +76,7 @@ public data class YamlScalar(
                 content.startsWith("-0o") -> converter("-" + content.substring(3), 8)
                 else -> converter(content, 10)
             }
-        } catch (e: NumberFormatException) {
+        } catch (_: NumberFormatException) {
             null
         }
 
@@ -97,11 +97,7 @@ public data class YamlScalar(
             else -> {
                 try {
                     content.toFloat()
-                } catch (e: NumberFormatException) {
-                    throw YamlScalarFormatException("Value '$content' is not a valid floating point value.", path, content)
-                } catch (e: IndexOutOfBoundsException) {
-                    // Workaround for https://youtrack.jetbrains.com/issue/KT-69327
-                    // TODO: remove once it is fixed
+                } catch (_: NumberFormatException) {
                     throw YamlScalarFormatException("Value '$content' is not a valid floating point value.", path, content)
                 }
             }
@@ -128,11 +124,7 @@ public data class YamlScalar(
             else -> {
                 try {
                     content.toDouble()
-                } catch (e: NumberFormatException) {
-                    null
-                } catch (e: IndexOutOfBoundsException) {
-                    // Workaround for https://youtrack.jetbrains.com/issue/KT-69327
-                    // TODO: remove once it is fixed
+                } catch (_: NumberFormatException) {
                     null
                 }
             }

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlScalarTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlScalarTest.kt
@@ -250,14 +250,6 @@ class YamlScalarTest :
 
                     val floatingPointTestCondition: EnabledOrReasonIf = {
                         when (kotlinTarget) {
-                            KotlinTarget.NATIVE -> {
-                                if (content == "1e-") {
-                                    disabled("floating point parser bug: https://youtrack.jetbrains.com/issue/KT-69327")
-                                } else {
-                                    enabled
-                                }
-                            }
-
                             KotlinTarget.JS -> {
                                 if (content in setOf("0x2", "0o2")) {
                                     disabled("$content is a valid floating value for JS due to dynamic cast")


### PR DESCRIPTION
KT-69327 (Kotlin/Native floating point parser throwing `IndexOutOfBoundsException` instead of `NumberFormatException`) is fixed. The workaround is no longer needed on Kotlin 2.4.10.

## Changes

- `YamlNode.kt` — removed both `catch (e: IndexOutOfBoundsException)` blocks from `toFloatOrNull` and `toDoubleOrNull`
- `YamlScalarTest.kt` — removed the `KotlinTarget.NATIVE` branch that disabled the `1e-` case
- Unused catch parameters renamed `e` -> `_`

## Verification

586 tests pass, 0 ignored, on: `macosArm64`, `iosSimulatorArm64`, `jvm`, `jsNode`, `wasmJsNode`.

`linuxX64`, `linuxArm64` and `mingwX64` cannot run on a macOS host — CI covers those.

Note: `--tests '*YamlScalarTest*'` does not filter Kotest on Native (the spec is silently skipped). Run the full target task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)