### PR TITLE
feat(common): support collection-style access to YamlList and YamlMap 

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
@@ -184,7 +184,14 @@ public data class YamlNull(
 public data class YamlList(
     val items: List<YamlNode>,
     override val path: YamlPath,
-) : YamlNode(path) {
+) : YamlNode(path),
+    Iterable<YamlNode> {
+    /** The number of items in this list. */
+    public val size: Int
+        get() = items.size
+
+    override fun iterator(): Iterator<YamlNode> = items.iterator()
+
     override fun equivalentContentTo(other: YamlNode): Boolean {
         if (other !is YamlList) {
             return false
@@ -229,7 +236,14 @@ public data class YamlList(
 public data class YamlMap(
     val entries: Map<YamlScalar, YamlNode>,
     override val path: YamlPath,
-) : YamlNode(path) {
+) : YamlNode(path),
+    Iterable<Map.Entry<YamlScalar, YamlNode>> {
+    /** The number of entries in this map. */
+    public val size: Int
+        get() = entries.size
+
+    override fun iterator(): Iterator<Map.Entry<YamlScalar, YamlNode>> = entries.iterator()
+
     init {
         val keys =
             entries.keys.sortedWith { a, b ->
@@ -369,6 +383,47 @@ public val YamlNode.yamlMap: YamlMap
 
 public val YamlNode.yamlTaggedNode: YamlTaggedNode
     get() = this as? YamlTaggedNode ?: error(this, "YamlTaggedNode")
+
+/**
+ * Returns a map containing the results of applying the given [transform] function
+ * to each entry in this map.
+ *
+ * The returned map is a plain [Map] with the transformed keys and the original values,
+ * so it can be used with all the standard library functions for maps.
+ */
+public fun <R> YamlMap.mapKeys(transform: (Map.Entry<YamlScalar, YamlNode>) -> R): Map<R, YamlNode> =
+    entries.mapKeys(transform)
+
+/**
+ * Returns a map containing the results of applying the given [transform] function
+ * to each entry in this map.
+ *
+ * The returned map is a plain [Map] with the original keys and the transformed values,
+ * so it can be used with all the standard library functions for maps.
+ */
+public fun <R> YamlMap.mapValues(transform: (Map.Entry<YamlScalar, YamlNode>) -> R): Map<YamlScalar, R> =
+    entries.mapValues(transform)
+
+/**
+ * Returns a [YamlMap] containing only the entries whose keys match the given [predicate].
+ */
+public fun YamlMap.filterKeys(predicate: (YamlScalar) -> Boolean): YamlMap =
+    YamlMap(entries.filterKeys(predicate), path)
+
+/**
+ * Returns a [YamlMap] containing only the entries whose values match the given [predicate].
+ */
+public fun YamlMap.filterValues(predicate: (YamlNode) -> Boolean): YamlMap =
+    YamlMap(entries.filterValues(predicate), path)
+
+/**
+ * Returns the value corresponding to the given [key], or throws [NoSuchElementException]
+ * if no such key is present in the map.
+ *
+ * Unlike [get], this function returns the value regardless of its type.
+ */
+public fun YamlMap.getValue(key: String): YamlNode =
+    get<YamlNode>(key) ?: throw NoSuchElementException("Key '$key' is not present in this map.")
 
 private fun error(
     node: YamlNode,

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlListTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlListTest.kt
@@ -85,6 +85,23 @@ class YamlListTest :
             shouldThrow<IndexOutOfBoundsException> { listElements[10] }
         }
 
+        test("iterating over list yields its items in order") {
+            listElements.toList() shouldBe listElements.items
+        }
+
+        test("list size matches its items") {
+            listElements.size shouldBe 2
+        }
+
+        test("mapping over list without accessing items property") {
+            listElements.map { it.yamlScalar.content } shouldBe listOf("item 1", "item 2")
+        }
+
+        test("associating list elements without accessing items property") {
+            listElements.associate { it.yamlScalar.content to it.path } shouldBe
+                mapOf("item 1" to firstItemPath, "item 2" to secondItemPath)
+        }
+
         test("converting content of an empty list to a human-readable string") {
             val listEmpty = YamlList(emptyList(), YamlPath.root)
             listEmpty.contentToString() shouldBe "[]"

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlMapTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlMapTest.kt
@@ -273,6 +273,82 @@ class YamlMapTest :
                 }
             }
 
+            context("using the map as a collection") {
+                val helloKeyPath = YamlPath.root.withMapElementKey("hello", Location(1, 1))
+                val helloValuePath = helloKeyPath.withMapElementValue(Location(2, 1))
+                val alsoKeyPath = YamlPath.root.withMapElementKey("also", Location(3, 1))
+                val alsoValuePath = alsoKeyPath.withMapElementValue(Location(4, 1))
+
+                val helloKey = YamlScalar("hello", helloKeyPath)
+                val helloValue = YamlScalar("world", helloValuePath)
+                val alsoKey = YamlScalar("also", alsoKeyPath)
+                val alsoValue = YamlScalar("something", alsoValuePath)
+
+                val map = YamlMap(mapOf(helloKey to helloValue, alsoKey to alsoValue), YamlPath.root)
+
+                test("iterating over map yields its entries in order") {
+                    val contents = mutableListOf<String>()
+
+                    for ((key, value) in map) {
+                        contents += "${key.content}=${value.yamlScalar.content}"
+                    }
+
+                    contents shouldBe listOf("hello=world", "also=something")
+                }
+
+                test("map size matches its entries") {
+                    map.size shouldBe 2
+                }
+
+                test("mapping over map without accessing entries property") {
+                    map.map { (key, value) -> key.content to value.yamlScalar.content } shouldBe
+                        listOf("hello" to "world", "also" to "something")
+                }
+
+                test("associating map entries without accessing entries property") {
+                    map.associate { (key, value) -> key.content to value.yamlScalar.content } shouldBe
+                        mapOf("hello" to "world", "also" to "something")
+                }
+
+                test("mapping keys produces a plain map with transformed keys") {
+                    map.mapKeys { (key, _) -> key.content.uppercase() } shouldBe
+                        mapOf("HELLO" to helloValue, "ALSO" to alsoValue)
+                }
+
+                test("mapping values produces a plain map with transformed values") {
+                    map.mapValues { (_, value) -> value.yamlScalar.content.uppercase() } shouldBe
+                        mapOf(helloKey to "WORLD", alsoKey to "SOMETHING")
+                }
+
+                test("filtering keys produces a YamlMap with the matching entries") {
+                    map.filterKeys { it.content.startsWith("h") } shouldBe
+                        YamlMap(mapOf(helloKey to helloValue), YamlPath.root)
+                }
+
+                test("filtering values produces a YamlMap with the matching entries") {
+                    map.filterValues { it.yamlScalar.content.length > 5 } shouldBe
+                        YamlMap(mapOf(alsoKey to alsoValue), YamlPath.root)
+                }
+
+                test("getting a value by its string key returns the value") {
+                    map.getValue("hello") shouldBe helloValue
+                }
+
+                test("getting a value for a missing key throws NoSuchElementException") {
+                    shouldThrow<NoSuchElementException> { map.getValue("missing") }
+                }
+
+                test("key-centric operations compose with iteration") {
+                    val (key, value) = map
+                        .filterKeys { it.content.startsWith("h") }
+                        .mapValues { (_, value) -> value.yamlScalar.content }
+                        .entries
+                        .first()
+
+                    key.content to value shouldBe ("hello" to "world")
+                }
+            }
+
             context("getting scalar elements of the map") {
                 val helloKeyPath = YamlPath.root.withMapElementKey("hello", Location(1, 1))
                 val helloValuePath = helloKeyPath.withMapElementValue(Location(2, 1))


### PR DESCRIPTION
Makes `YamlList` and `YamlMap` iterable, so collection functions like `map()` and `associate()` work on them directly instead of on `.items` / `.entries`. `YamlMap` additionally gets `mapKeys`, `mapValues`, `filterKeys`, `filterValues` and `getValue(key)` extensions for the key-based operations that iteration can't express.

The concrete code this enables:

```kotlin
// before
node.yamlMap.entries.associate { (key, value) -> key.content to value.yamlScalar.content }
// after
node.yamlMap.associate { (key, value) -> key.content to value.yamlScalar.content }
```

This is a polishment of #24, I still implement `Iterable` for `YamlMap` because `.associate` is only available on `Iterable`, and can reduce a lot of custom extension functions for `YamlMap`.